### PR TITLE
Feature#2 Axios 인터셉터 및 커스텀 에러 핸들링 추가

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,10 +1,7 @@
 {
   "printWidth": 120,
-  "tabWidth": 4,
-  "plugins": [
-    "@trivago/prettier-plugin-sort-imports",
-    "prettier-plugin-tailwindcss"
-  ],
+  "tabWidth": 2,
+  "plugins": ["@trivago/prettier-plugin-sort-imports", "prettier-plugin-tailwindcss"],
 
   "importOrder": [
     "reflect-metadata",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
+    "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.6.14",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       globals:
         specifier: ^16.3.0
         version: 16.3.0
+      prettier:
+        specifier: ^3.6.2
+        version: 3.6.2
       prettier-plugin-tailwindcss:
         specifier: ^0.6.14
         version: 0.6.14(@trivago/prettier-plugin-sort-imports@5.2.2(prettier@3.6.2))(prettier@3.6.2)

--- a/src/constants/error-configs.ts
+++ b/src/constants/error-configs.ts
@@ -1,38 +1,40 @@
+import type { ErrorCode } from "@/errors/types";
+
 export const ERROR_CONFIGS = {
   BAD_REQUEST: {
     statusCode: 400,
-    defaultMessage: '잘못된 요청입니다.',
+    defaultMessage: "잘못된 요청입니다.",
   },
   UNAUTHORIZED: {
     statusCode: 401,
-    defaultMessage: '인증되지 않은 사용자입니다.',
+    defaultMessage: "인증되지 않은 사용자입니다.",
   },
   FORBIDDEN: {
     statusCode: 403,
-    defaultMessage: '접근 권한이 없습니다.',
+    defaultMessage: "접근 권한이 없습니다.",
   },
   NOT_FOUND: {
     statusCode: 404,
-    defaultMessage: '리소스를 찾을 수 없습니다.',
+    defaultMessage: "리소스를 찾을 수 없습니다.",
   },
   SERVER_ERROR: {
     statusCode: 500,
-    defaultMessage: '서버 오류입니다.',
+    defaultMessage: "서버 오류입니다.",
   },
   NETWORK_ERROR: {
     statusCode: undefined,
-    defaultMessage: '네트워크 요청이 실패하였습니다.',
+    defaultMessage: "네트워크 요청이 실패하였습니다.",
   },
   TOKEN_EXPIRED: {
     statusCode: 401,
-    defaultMessage: '토큰이 만료되었습니다.',
+    defaultMessage: "토큰이 만료되었습니다.",
   },
   VALIDATION_ERROR: {
     statusCode: 422,
-    defaultMessage: '유효성 검증에 실패하였습니다.',
+    defaultMessage: "유효성 검증에 실패하였습니다.",
   },
   UNKNOWN_ERROR: {
     statusCode: undefined,
-    defaultMessage: '알 수 없는 오류입니다.',
+    defaultMessage: "알 수 없는 오류입니다.",
   },
-} as const;
+} as const satisfies Record<ErrorCode, { statusCode?: number; defaultMessage: string }>;

--- a/src/constants/error-configs.ts
+++ b/src/constants/error-configs.ts
@@ -21,6 +21,18 @@ export const ERROR_CONFIGS = {
     statusCode: 500,
     defaultMessage: "서버 오류입니다.",
   },
+  BAD_GATEWAY: {
+    statusCode: 502,
+    defaultMessage: "게이트웨이 오류입니다.",
+  },
+  SERVICE_UNAVAILABLE: {
+    statusCode: 503,
+    defaultMessage: "서비스를 일시적으로 사용할 수 없습니다.",
+  },
+  GATEWAY_TIMEOUT: {
+    statusCode: 504,
+    defaultMessage: "게이트웨이 응답 시간이 초과되었습니다.",
+  },
   NETWORK_ERROR: {
     statusCode: undefined,
     defaultMessage: "네트워크 요청이 실패하였습니다.",

--- a/src/constants/error-configs.ts
+++ b/src/constants/error-configs.ts
@@ -1,4 +1,4 @@
-import type { ErrorCode } from "@/errors/types";
+import type { ErrorCode, ErrorConfigEntry } from "@/errors/types";
 
 export const ERROR_CONFIGS = {
   BAD_REQUEST: {
@@ -49,4 +49,4 @@ export const ERROR_CONFIGS = {
     statusCode: undefined,
     defaultMessage: "알 수 없는 오류입니다.",
   },
-} as const satisfies Record<ErrorCode, { statusCode?: number; defaultMessage: string }>;
+} as const satisfies Record<ErrorCode, ErrorConfigEntry>;

--- a/src/constants/error-configs.ts
+++ b/src/constants/error-configs.ts
@@ -1,0 +1,38 @@
+export const ERROR_CONFIGS = {
+  BAD_REQUEST: {
+    statusCode: 400,
+    defaultMessage: '잘못된 요청입니다.',
+  },
+  UNAUTHORIZED: {
+    statusCode: 401,
+    defaultMessage: '인증되지 않은 사용자입니다.',
+  },
+  FORBIDDEN: {
+    statusCode: 403,
+    defaultMessage: '접근 권한이 없습니다.',
+  },
+  NOT_FOUND: {
+    statusCode: 404,
+    defaultMessage: '리소스를 찾을 수 없습니다.',
+  },
+  SERVER_ERROR: {
+    statusCode: 500,
+    defaultMessage: '서버 오류입니다.',
+  },
+  NETWORK_ERROR: {
+    statusCode: undefined,
+    defaultMessage: '네트워크 요청이 실패하였습니다.',
+  },
+  TOKEN_EXPIRED: {
+    statusCode: 401,
+    defaultMessage: '토큰이 만료되었습니다.',
+  },
+  VALIDATION_ERROR: {
+    statusCode: 422,
+    defaultMessage: '유효성 검증에 실패하였습니다.',
+  },
+  UNKNOWN_ERROR: {
+    statusCode: undefined,
+    defaultMessage: '알 수 없는 오류입니다.',
+  },
+} as const;

--- a/src/errors/api-errors.ts
+++ b/src/errors/api-errors.ts
@@ -1,19 +1,19 @@
 import type { ErrorCode, ErrorConfig } from "@/errors/types";
 
-export class ApiError extends Error{
-  public readonly code:ErrorCode;
-  public readonly statusCode:number | undefined;
-  public readonly metadata?:Record<string,unknown>;
+export class ApiError extends Error {
+  public readonly code: ErrorCode;
+  public readonly statusCode: number | undefined;
+  public readonly metadata?: Record<string, unknown>;
 
-  constructor(config:ErrorConfig) {
+  constructor(config: ErrorConfig) {
     super(config.message);
-    this.name="ApiError";
-    this.code = config.code as ErrorCode;
-    this.statusCode=  config.statusCode;
+    this.name = "ApiError";
+    this.code = config.code;
+    this.statusCode = config.statusCode;
     this.metadata = config.metadata;
 
-    if(Error.captureStackTrace){
-      Error.captureStackTrace(this,this.constructor);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
     }
   }
 }

--- a/src/errors/api-errors.ts
+++ b/src/errors/api-errors.ts
@@ -1,0 +1,19 @@
+import type { ErrorCode, ErrorConfig } from "@/errors/types";
+
+export class ApiError extends Error{
+  public readonly code:ErrorCode;
+  public readonly statusCode:number | undefined;
+  public readonly metadata?:Record<string,unknown>;
+
+  constructor(config:ErrorConfig) {
+    super(config.message);
+    this.name="ApiError";
+    this.code = config.code as ErrorCode;
+    this.statusCode=  config.statusCode;
+    this.metadata = config.metadata;
+
+    if(Error.captureStackTrace){
+      Error.captureStackTrace(this,this.constructor);
+    }
+  }
+}

--- a/src/errors/error-factory.ts
+++ b/src/errors/error-factory.ts
@@ -10,9 +10,9 @@ const statusCodeMap: Record<number, ErrorCode> = {
         404: "NOT_FOUND",
         422: "VALIDATION_ERROR",
         500: "SERVER_ERROR",
-        502: "SERVER_ERROR",
-        503: "SERVER_ERROR", 
-        504: "SERVER_ERROR",
+        502: "BAD_GATEWAY",
+        503: "SERVICE_UNAVAILABLE",
+        504: "GATEWAY_TIMEOUT",
       };
 
 export class ErrorFactory{
@@ -20,11 +20,12 @@ export class ErrorFactory{
         code:ErrorCode,
         message?:string,
         metadata?:Record<string,unknown>,
+        statusCode?:number,
     ):ApiError{
         const config = ERROR_CONFIGS[code] ?? ERROR_CONFIGS.UNKNOWN_ERROR;
         return new ApiError({
             code,
-            statusCode:config.statusCode,
+            statusCode: statusCode ?? config.statusCode,
             message:message || config.defaultMessage,
             metadata,
     })}
@@ -35,7 +36,7 @@ export class ErrorFactory{
       metadata?:Record<string,unknown>,
     ):ApiError{
       const code = statusCodeMap[statusCode] ?? "UNKNOWN_ERROR";
-      return this.create(code, message, metadata);
+      return this.create(code, message, metadata, statusCode);
     }
 
     static fromAxiosError(

--- a/src/errors/error-factory.ts
+++ b/src/errors/error-factory.ts
@@ -1,0 +1,57 @@
+import { ERROR_CONFIGS } from "@/constants/error-configs";
+import { ApiError } from "@/errors/api-errors";
+import type { ErrorCode } from "@/errors/types";
+import type { AxiosError } from "axios";
+
+const statusCodeMap: Record<number, ErrorCode> = {
+        400: "BAD_REQUEST",
+        401: "UNAUTHORIZED", 
+        403: "FORBIDDEN",
+        404: "NOT_FOUND",
+        422: "VALIDATION_ERROR",
+        500: "SERVER_ERROR",
+        502: "SERVER_ERROR",
+        503: "SERVER_ERROR", 
+        504: "SERVER_ERROR",
+      };
+
+export class ErrorFactory{
+    static create(
+        code:ErrorCode,
+        message?:string,
+        metadata?:Record<string,unknown>,
+    ):ApiError{
+        const config = ERROR_CONFIGS[code] ?? ERROR_CONFIGS.UNKNOWN_ERROR;
+        return new ApiError({
+            code,
+            statusCode:config.statusCode,
+            message:message || config.defaultMessage,
+            metadata,
+    })}
+
+    static fromStatusCode(
+      statusCode:number,
+      message?:string,
+      metadata?:Record<string,unknown>,
+    ):ApiError{
+      const code = statusCodeMap[statusCode] ?? "UNKNOWN_ERROR";
+      return this.create(code, message, metadata);
+    }
+
+    static fromAxiosError(
+      error: AxiosError<BaseErrorResponse>
+    ):ApiError{
+      if(!error.response){
+        return this.create("NETWORK_ERROR",error.message);
+      }
+      const {status,data} = error.response;
+      const message = data?.message || error.message;
+      
+      const metadata = data?.metadata;
+
+      if(status===401 && data?.code ==="TOKEN_EXPIRED"){
+        return this.create("TOKEN_EXPIRED",message,metadata);
+      }
+      return this.fromStatusCode(status,message,metadata);
+    }
+}

--- a/src/errors/types.ts
+++ b/src/errors/types.ts
@@ -1,0 +1,17 @@
+export interface ErrorConfig {
+    code:string;
+    statusCode?:number;
+    message:string;
+    metadata?:Record<string,unknown>;
+}
+
+export type ErrorCode = 
+  | 'BAD_REQUEST'
+  | 'UNAUTHORIZED'
+  | 'FORBIDDEN'
+  | 'NOT_FOUND'
+  | 'SERVER_ERROR'
+  | 'NETWORK_ERROR'
+  | 'TOKEN_EXPIRED'
+  | 'VALIDATION_ERROR'
+  | 'UNKNOWN_ERROR';

--- a/src/errors/types.ts
+++ b/src/errors/types.ts
@@ -1,17 +1,20 @@
 export interface ErrorConfig {
-    code:string;
-    statusCode?:number;
-    message:string;
-    metadata?:Record<string,unknown>;
+  code: ErrorCode;
+  statusCode?: number;
+  message: string;
+  metadata?: Record<string, unknown>;
 }
 
-export type ErrorCode = 
-  | 'BAD_REQUEST'
-  | 'UNAUTHORIZED'
-  | 'FORBIDDEN'
-  | 'NOT_FOUND'
-  | 'SERVER_ERROR'
-  | 'NETWORK_ERROR'
-  | 'TOKEN_EXPIRED'
-  | 'VALIDATION_ERROR'
-  | 'UNKNOWN_ERROR';
+export type ErrorCode =
+  | "BAD_REQUEST"
+  | "UNAUTHORIZED"
+  | "FORBIDDEN"
+  | "NOT_FOUND"
+  | "SERVER_ERROR"
+  | "BAD_GATEWAY"
+  | "SERVICE_UNAVAILABLE"
+  | "GATEWAY_TIMEOUT"
+  | "NETWORK_ERROR"
+  | "TOKEN_EXPIRED"
+  | "VALIDATION_ERROR"
+  | "UNKNOWN_ERROR";

--- a/src/errors/types.ts
+++ b/src/errors/types.ts
@@ -5,6 +5,11 @@ export interface ErrorConfig {
   metadata?: Record<string, unknown>;
 }
 
+export interface ErrorConfigEntry {
+  statusCode?: number;
+  defaultMessage: string;
+}
+
 export type ErrorCode =
   | "BAD_REQUEST"
   | "UNAUTHORIZED"

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -7,16 +7,15 @@ export const api = axios.create({
   baseURL,
   timeout: 10000,
   headers: {
-    'Content-Type': 'application/json',
+    "Content-Type": "application/json",
   },
 });
-
 
 api.interceptors.response.use(
   (response) => {
     return response;
   },
   (error) => {
-   throw ErrorFactory.fromAxiosError(error); 
-  }
-)
+    throw ErrorFactory.fromAxiosError(error);
+  },
+);

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,0 +1,22 @@
+import { ErrorFactory } from "@/errors/error-factory";
+import axios from "axios";
+
+const baseURL = import.meta.env.VITE_API_BASE_URL;
+
+export const api = axios.create({
+  baseURL,
+  timeout: 10000,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+
+api.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  (error) => {
+   throw ErrorFactory.fromAxiosError(error); 
+  }
+)

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,0 +1,1 @@
+export { api } from './axios';

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -1,0 +1,11 @@
+declare interface BaseResponse<T>{
+    message:string;
+    data:T;
+    success:boolean;
+}
+
+declare interface BaseErrorResponse{
+    code?:string;
+    message?:string;
+    metadata?:Record<string,unknown>;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "files": [],
-  "references": [
-    { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
-  ]
+  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
 }


### PR DESCRIPTION
### 1️⃣ PR 타입 (PR Type)

<!-- 해당하는 곳에 `x`를 표시해주세요. -->

- [x] ✨ feat: 새로운 기능 추가

### 2️⃣ 변경 사항 (Changes)

- api 요청/응답에서 에러 처리를 위한 클래스 구현

### 3️⃣ 관련 이슈 (Related Issues)

- #2 

### 4️⃣ 코드 설명 (Description)

- Axios Interceptor에서는 인증 실패, 토큰 만료 등과 같은 공통적인 예외 상황을 감지하여 ApiError를 throw하는 방식으로 작성했습니다.
- 최종적으로는 컴포넌트나 페이지 등 UI 계층에서 try/catch를 통해 에러를 받아, 상황에 맞는 사용자 피드백(예: 토스트 메시지, 페이지 이동 등)을 처리하는 구조입니다.

1. ErrorFactory: AxiosError를 BaseErrorResponse 타입으로 변환하여 커스텀 ApiError 생성
2. Axios Interceptor: 공통 예외 상황 감지 (401, 토큰 만료 등)

케이스1 - 토큰 만료, 네트워크 에러
- API 호출 실패 → Interceptor에서 감지 → ErrorFactory가 AxiosError를 ApiError로 변환 → UI에서 catch하여 사용자 피드백 처리

케이스2 - 일반적인 HTTP 에러
- API 호출 실패 → statusCodeMap에 있는 에러 매핑(매핑되지 않은 상태 코드는 UNKNOWN_ERROR로 처리)  → fromStatusCode에서 에러 변환 → UI에서 catch하여 사용자 피드백 처리

### ✅ 체크리스트 (Checklist)

- [x] `base branch`를 확인했나요?
- [x] `self-review`를 진행했나요?
- [x] 관련 이슈를 연결했나요?
- [x] 커밋 컨벤션을 준수했나요?
- [x] PR 제목 컨벤션을 준수했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified API client with timeout, JSON defaults and response interception.
  * Consistent error handling that normalizes HTTP/network responses into localized (Korean) messages.
  * Expanded standard error codes including gateway/service availability and token-expired handling; programmatic error creation utilities.

* **Chores**
  * Added shared API/error types and ambient response/error interfaces.
  * Formatting/tooling updates and TypeScript path/config changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->