### PR TITLE
Feature#27 프로필 보기 확인, 마니또 페이지

### DIFF
--- a/src/components/profilecheck/ProfileCheckComplete.tsx
+++ b/src/components/profilecheck/ProfileCheckComplete.tsx
@@ -1,0 +1,17 @@
+import { Check } from "lucide-react";
+
+const ProfileCheckComplete = () => {
+  return (
+    <div className="mt-0 flex flex-col items-center space-y-4">
+      <div className="bg-primary flex h-20 w-20 items-center justify-center rounded-full">
+        <Check className="h-8 w-8 text-white" />
+      </div>
+      <div className="text-center">
+        <div className="mb-2 text-2xl font-bold text-black">모든 프로필 확인 완료!</div>
+        <p className="text-sm text-gray-600">이제 함께 아이스브레이킹을 시작해보세요</p>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileCheckComplete;

--- a/src/components/profilecheck/ProfileCheckReadyButton.tsx
+++ b/src/components/profilecheck/ProfileCheckReadyButton.tsx
@@ -1,0 +1,15 @@
+import { Button } from "@/components/common";
+
+interface ProfileCheckReadyButtonProps {
+  onReadyClick: () => void;
+}
+
+const ProfileCheckReadyButton = ({ onReadyClick }: ProfileCheckReadyButtonProps) => {
+  return (
+    <Button onClick={onReadyClick} className="mt-4 w-full text-[18px] font-semibold">
+      준비 완료
+    </Button>
+  );
+};
+
+export default ProfileCheckReadyButton;

--- a/src/components/profilecheck/ProfileCheckStatus.tsx
+++ b/src/components/profilecheck/ProfileCheckStatus.tsx
@@ -1,0 +1,35 @@
+interface Member {
+  name: string;
+  isReady: boolean;
+}
+
+interface ProfileCheckStatusProps {
+  members: Member[];
+}
+
+const ProfileCheckStatus = ({ members }: ProfileCheckStatusProps) => {
+  return (
+    <div className="mt-6 h-[340px] w-full rounded-[16px] bg-white p-4 shadow-md">
+      <h3 className="text-md mb-4 flex justify-center font-bold text-black">준비 상태</h3>
+      <div className="space-y-2">
+        {members.map((member) => (
+          <div
+            key={member.name}
+            className="text-md flex h-14 items-center justify-between rounded-[8px] bg-[#F9FAFB] px-6 text-gray-800"
+          >
+            {member.name}
+            <span
+              className={`text-md rounded-full px-4 py-1 ${
+                member.isReady ? "bg-[#DCFCE7] text-[#15803D]" : "bg-[#FEF9C3] text-[#A16207]"
+              }`}
+            >
+              {member.isReady ? "준비 완료" : "대기 중"}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ProfileCheckStatus;

--- a/src/components/profilecheck/index.tsx
+++ b/src/components/profilecheck/index.tsx
@@ -1,0 +1,3 @@
+export { default as ProfileCheckComplete } from "./ProfileCheckComplete";
+export { default as ProfileCheckStatus } from "./ProfileCheckStatus";
+export { default as ProfileCheckReadyButton } from "./ProfileCheckReadyButton";

--- a/src/pages/ManittoPage.tsx
+++ b/src/pages/ManittoPage.tsx
@@ -1,0 +1,16 @@
+import { AppScreen } from "@stackflow/plugin-basic-ui";
+import type { ActivityComponentType } from "@stackflow/react/future";
+
+const ManittoPage: ActivityComponentType<"ManittoPage"> = () => {
+  return (
+    <AppScreen appBar={{ title: "마니또" }}>
+      <main className="bg-gradient-primary min-h-screen p-4">
+        <div className="flex flex-col items-center">
+          <h1 className="text-2xl">마니또 페이지</h1>
+        </div>
+      </main>
+    </AppScreen>
+  );
+};
+
+export default ManittoPage;

--- a/src/pages/ManittoPage.tsx
+++ b/src/pages/ManittoPage.tsx
@@ -1,12 +1,29 @@
+import { ProfileCard } from "@/components/profileview";
+import type { Profile } from "@/components/profileview/types";
 import { AppScreen } from "@stackflow/plugin-basic-ui";
 import type { ActivityComponentType } from "@stackflow/react/future";
 
 const ManittoPage: ActivityComponentType<"ManittoPage"> = () => {
+  const manittoProfile: Profile = {
+    profileId: 1,
+    name: "김민수",
+    age: 25,
+    mbti: "ENFP",
+    interests: ["영화", "음악", "여행", "운동"],
+    intro: "새로운 사람들과 만나는 것을 좋아해요! 함께 즐거운 시간 보내요 😊",
+  };
+
   return (
     <AppScreen appBar={{ title: "마니또" }}>
       <main className="bg-gradient-primary min-h-screen p-4">
         <div className="flex flex-col items-center">
-          <h1 className="text-2xl">마니또 페이지</h1>
+          {/* 상단 안내 텍스트 */}
+          <div className="mb-6 text-center">
+            <p className="text-xl font-semibold text-black">나의 마니또를 확인하세요</p>
+          </div>
+
+          {/* 마니또 프로필 카드 */}
+          <ProfileCard profile={manittoProfile} />
         </div>
       </main>
     </AppScreen>

--- a/src/pages/ManittoPage.tsx
+++ b/src/pages/ManittoPage.tsx
@@ -9,8 +9,9 @@ const ManittoPage: ActivityComponentType<"ManittoPage"> = () => {
     name: "김민수",
     age: 25,
     mbti: "ENFP",
-    interests: ["영화", "음악", "여행", "운동"],
-    intro: "새로운 사람들과 만나는 것을 좋아해요! 함께 즐거운 시간 보내요 😊",
+    interests: ["스포츠", "음악", "영화", "독서", "여행", "요리", "게임", "동물"],
+    intro:
+      "새로운 사람들과 만나는 것을 좋아해요! 함께 즐거운 시간 보내요 새로운 사람들과 만나는 것을 좋아해요! 함께 즐거운 시간 보내요 새로운 사람들과 만나는 것을 좋아해요! 함께 즐거운",
   };
 
   return (

--- a/src/pages/ProfileCheckPage.tsx
+++ b/src/pages/ProfileCheckPage.tsx
@@ -1,8 +1,7 @@
-import { Button } from "@/components/common";
+import { ProfileCheckComplete, ProfileCheckReadyButton, ProfileCheckStatus } from "@/components/profilecheck";
 import { AppScreen } from "@stackflow/plugin-basic-ui";
 import type { ActivityComponentType } from "@stackflow/react/future";
 import { useFlow } from "@stackflow/react/future";
-import { Check } from "lucide-react";
 import { useEffect, useState } from "react";
 
 const ProfileCheckPage: ActivityComponentType<"ProfileCheckPage"> = () => {
@@ -33,43 +32,9 @@ const ProfileCheckPage: ActivityComponentType<"ProfileCheckPage"> = () => {
     <AppScreen appBar={{ title: "프로필 소개" }}>
       <main className="bg-gradient-primary min-h-screen p-4">
         <div className="flex flex-col items-center">
-          {/* 완료 아이콘과 메시지 */}
-          <div className="mt-0 flex flex-col items-center space-y-4">
-            <div className="bg-primary flex h-20 w-20 items-center justify-center rounded-full">
-              <Check className="h-8 w-8 text-white" />
-            </div>
-            <div className="text-center">
-              <div className="mb-2 text-2xl font-bold text-black">모든 프로필 확인 완료!</div>
-              <p className="text-sm text-gray-600">이제 함께 아이스브레이킹을 시작해보세요</p>
-            </div>
-          </div>
-
-          {/* 준비 상태 카드 */}
-          <div className="mt-6 h-[340px] w-full rounded-[16px] bg-white p-4 shadow-md">
-            <h3 className="text-md mb-4 flex justify-center font-bold text-black">준비 상태</h3>
-            <div className="space-y-2">
-              {members.map((member) => (
-                <div
-                  key={member.name}
-                  className="text-md flex h-14 items-center justify-between rounded-[8px] bg-[#F9FAFB] px-6 text-gray-800"
-                >
-                  {member.name}
-                  <span
-                    className={`text-md rounded-full px-4 py-1 ${
-                      member.isReady ? "bg-[#DCFCE7] text-[#15803D]" : "bg-[#FEF9C3] text-[#A16207]"
-                    }`}
-                  >
-                    {member.isReady ? "준비 완료" : "대기 중"}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          {/* 준비 완료 버튼 */}
-          <Button onClick={handleReadyClick} className="mt-4 w-full text-[18px] font-semibold">
-            준비 완료
-          </Button>
+          <ProfileCheckComplete />
+          <ProfileCheckStatus members={members} />
+          <ProfileCheckReadyButton onReadyClick={handleReadyClick} />
         </div>
       </main>
     </AppScreen>

--- a/src/pages/ProfileCheckPage.tsx
+++ b/src/pages/ProfileCheckPage.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@/components/common";
 import { AppScreen } from "@stackflow/plugin-basic-ui";
 import type { ActivityComponentType } from "@stackflow/react/future";
 import { Check } from "lucide-react";
@@ -5,7 +6,7 @@ import { Check } from "lucide-react";
 const ProfileCheckPage: ActivityComponentType<"ProfileCheckPage"> = () => {
   return (
     <AppScreen appBar={{ title: "프로필 소개" }}>
-      <main className="bg-gradient-primary p-4">
+      <main className="bg-gradient-primary min-h-screen p-4">
         <div className="flex flex-col items-center">
           {/* 완료 아이콘과 메시지 */}
           <div className="mt-0 flex flex-col items-center space-y-4">
@@ -19,9 +20,9 @@ const ProfileCheckPage: ActivityComponentType<"ProfileCheckPage"> = () => {
           </div>
 
           {/* 준비 상태 카드 */}
-          <div className="mt-6 h-[350px] w-full rounded-[16px] bg-white p-4 shadow-md">
+          <div className="mt-6 h-[340px] w-full rounded-[16px] bg-white p-4 shadow-md">
             <h3 className="text-md mb-4 flex justify-center font-bold text-black">준비 상태</h3>
-            <div className="space-y-3">
+            <div className="space-y-2">
               <div className="text-md flex h-14 items-center justify-between rounded-[8px] bg-[#F9FAFB] px-6 text-gray-800">
                 김민수
                 <span className="text-md rounded-full bg-[#DCFCE7] px-4 py-1 text-[#15803D]">준비 완료</span>
@@ -40,6 +41,9 @@ const ProfileCheckPage: ActivityComponentType<"ProfileCheckPage"> = () => {
               </div>
             </div>
           </div>
+
+          {/* 준비 완료 버튼 */}
+          <Button className="mt-4 w-full text-[18px] font-semibold">준비 완료</Button>
         </div>
       </main>
     </AppScreen>

--- a/src/pages/ProfileCheckPage.tsx
+++ b/src/pages/ProfileCheckPage.tsx
@@ -8,13 +8,36 @@ const ProfileCheckPage: ActivityComponentType<"ProfileCheckPage"> = () => {
       <main className="bg-gradient-primary p-4">
         <div className="flex flex-col items-center">
           {/* 완료 아이콘과 메시지 */}
-          <div className="mt-4 flex flex-col items-center space-y-4">
+          <div className="mt-0 flex flex-col items-center space-y-4">
             <div className="bg-primary flex h-20 w-20 items-center justify-center rounded-full">
               <Check className="h-8 w-8 text-white" />
             </div>
             <div className="text-center">
               <div className="mb-2 text-2xl font-bold text-black">모든 프로필 확인 완료!</div>
               <p className="text-sm text-gray-600">이제 함께 아이스브레이킹을 시작해보세요</p>
+            </div>
+          </div>
+
+          {/* 준비 상태 카드 */}
+          <div className="mt-6 h-[350px] w-full rounded-[16px] bg-white p-4 shadow-md">
+            <h3 className="text-md mb-4 flex justify-center font-bold text-black">준비 상태</h3>
+            <div className="space-y-3">
+              <div className="text-md flex h-14 items-center justify-between rounded-[8px] bg-[#F9FAFB] px-6 text-gray-800">
+                김민수
+                <span className="text-md rounded-full bg-[#DCFCE7] px-4 py-1 text-[#15803D]">준비 완료</span>
+              </div>
+              <div className="text-md flex h-14 items-center justify-between rounded-[8px] bg-[#F9FAFB] px-6 text-gray-800">
+                이지은
+                <span className="text-md rounded-full bg-[#DCFCE7] px-4 py-1 text-[#15803D]">준비 완료</span>
+              </div>
+              <div className="text-md flex h-14 items-center justify-between rounded-[8px] bg-[#F9FAFB] px-6 text-gray-800">
+                박준혁
+                <span className="text-md rounded-full bg-[#FEF9C3] px-4 py-1 text-[#A16207]">대기 중 </span>
+              </div>
+              <div className="text-md flex h-14 items-center justify-between rounded-[8px] bg-[#F9FAFB] px-6 text-gray-800">
+                최민지
+                <span className="text-md rounded-full bg-[#FEF9C3] px-4 py-1 text-[#A16207]">대기 중 </span>
+              </div>
             </div>
           </div>
         </div>

--- a/src/pages/ProfileCheckPage.tsx
+++ b/src/pages/ProfileCheckPage.tsx
@@ -1,9 +1,34 @@
 import { Button } from "@/components/common";
 import { AppScreen } from "@stackflow/plugin-basic-ui";
 import type { ActivityComponentType } from "@stackflow/react/future";
+import { useFlow } from "@stackflow/react/future";
 import { Check } from "lucide-react";
+import { useEffect, useState } from "react";
 
 const ProfileCheckPage: ActivityComponentType<"ProfileCheckPage"> = () => {
+  const { push } = useFlow();
+  const [members, setMembers] = useState([
+    { name: "김민수", isReady: false },
+    { name: "이지은", isReady: true },
+    { name: "박준혁", isReady: true },
+    { name: "최민지", isReady: true },
+  ]);
+
+  const handleReadyClick = () => {
+    setMembers((prev) => prev.map((member, index) => (index === 0 ? { ...member, isReady: true } : member)));
+  };
+
+  useEffect(() => {
+    const allReady = members.every((member) => member.isReady);
+    if (allReady) {
+      const timer = setTimeout(() => {
+        push("MenuSelectPage", {});
+      }, 1000);
+
+      return () => clearTimeout(timer);
+    }
+  }, [members]);
+
   return (
     <AppScreen appBar={{ title: "프로필 소개" }}>
       <main className="bg-gradient-primary min-h-screen p-4">
@@ -23,27 +48,28 @@ const ProfileCheckPage: ActivityComponentType<"ProfileCheckPage"> = () => {
           <div className="mt-6 h-[340px] w-full rounded-[16px] bg-white p-4 shadow-md">
             <h3 className="text-md mb-4 flex justify-center font-bold text-black">준비 상태</h3>
             <div className="space-y-2">
-              <div className="text-md flex h-14 items-center justify-between rounded-[8px] bg-[#F9FAFB] px-6 text-gray-800">
-                김민수
-                <span className="text-md rounded-full bg-[#DCFCE7] px-4 py-1 text-[#15803D]">준비 완료</span>
-              </div>
-              <div className="text-md flex h-14 items-center justify-between rounded-[8px] bg-[#F9FAFB] px-6 text-gray-800">
-                이지은
-                <span className="text-md rounded-full bg-[#DCFCE7] px-4 py-1 text-[#15803D]">준비 완료</span>
-              </div>
-              <div className="text-md flex h-14 items-center justify-between rounded-[8px] bg-[#F9FAFB] px-6 text-gray-800">
-                박준혁
-                <span className="text-md rounded-full bg-[#FEF9C3] px-4 py-1 text-[#A16207]">대기 중 </span>
-              </div>
-              <div className="text-md flex h-14 items-center justify-between rounded-[8px] bg-[#F9FAFB] px-6 text-gray-800">
-                최민지
-                <span className="text-md rounded-full bg-[#FEF9C3] px-4 py-1 text-[#A16207]">대기 중 </span>
-              </div>
+              {members.map((member) => (
+                <div
+                  key={member.name}
+                  className="text-md flex h-14 items-center justify-between rounded-[8px] bg-[#F9FAFB] px-6 text-gray-800"
+                >
+                  {member.name}
+                  <span
+                    className={`text-md rounded-full px-4 py-1 ${
+                      member.isReady ? "bg-[#DCFCE7] text-[#15803D]" : "bg-[#FEF9C3] text-[#A16207]"
+                    }`}
+                  >
+                    {member.isReady ? "준비 완료" : "대기 중"}
+                  </span>
+                </div>
+              ))}
             </div>
           </div>
 
           {/* 준비 완료 버튼 */}
-          <Button className="mt-4 w-full text-[18px] font-semibold">준비 완료</Button>
+          <Button onClick={handleReadyClick} className="mt-4 w-full text-[18px] font-semibold">
+            준비 완료
+          </Button>
         </div>
       </main>
     </AppScreen>

--- a/src/pages/ProfileCheckPage.tsx
+++ b/src/pages/ProfileCheckPage.tsx
@@ -1,11 +1,23 @@
 import { AppScreen } from "@stackflow/plugin-basic-ui";
 import type { ActivityComponentType } from "@stackflow/react/future";
+import { Check } from "lucide-react";
 
 const ProfileCheckPage: ActivityComponentType<"ProfileCheckPage"> = () => {
   return (
     <AppScreen appBar={{ title: "프로필 소개" }}>
       <main className="bg-gradient-primary p-4">
-        <div className="flex flex-col items-center">프로필 확인 완료</div>
+        <div className="flex flex-col items-center">
+          {/* 완료 아이콘과 메시지 */}
+          <div className="mt-4 flex flex-col items-center space-y-4">
+            <div className="bg-primary flex h-20 w-20 items-center justify-center rounded-full">
+              <Check className="h-8 w-8 text-white" />
+            </div>
+            <div className="text-center">
+              <div className="mb-2 text-2xl font-bold text-black">모든 프로필 확인 완료!</div>
+              <p className="text-sm text-gray-600">이제 함께 아이스브레이킹을 시작해보세요</p>
+            </div>
+          </div>
+        </div>
       </main>
     </AppScreen>
   );

--- a/src/pages/ProfileViewPage.tsx
+++ b/src/pages/ProfileViewPage.tsx
@@ -29,13 +29,13 @@ const ProfileViewPage: ActivityComponentType<"ProfileViewPage"> = () => {
 
       if (nextIndex === 0) {
         push("ProfileCheckPage", { title: "프로필 확인" });
+        return;
       } else {
         setCurrentProfileIndex(nextIndex);
+        setTimeLeft(PROFILE_VIEW_TIME);
       }
-
-      setTimeLeft(PROFILE_VIEW_TIME);
     }
-  }, [timeLeft, currentProfileIndex, push]);
+  }, [timeLeft, currentProfileIndex]);
 
   const currentProfile = profiles[currentProfileIndex];
   const progressPercentage = ((PROFILE_VIEW_TIME - timeLeft) / PROFILE_VIEW_TIME) * PERCENTAGE_MULTIPLIER;

--- a/src/stackflow.config.ts
+++ b/src/stackflow.config.ts
@@ -16,6 +16,9 @@ export const config = defineConfig({
       name: "ProfileViewPage",
     },
     {
+      name: "ManittoPage",
+    },
+    {
       name: "CreateRoomPage",
     },
     {

--- a/src/stackflow.ts
+++ b/src/stackflow.ts
@@ -1,15 +1,17 @@
 import LandingPage from "@/pages/LandingPage";
+import ManittoPage from "@/pages/ManittoPage";
 import ProfileCheckPage from "@/pages/ProfileCheckPage";
 import ProfilePage from "@/pages/ProfilePage";
-import RandomRoulettePage from "@/pages/RandomRoulettePage";
 import ProfileViewPage from "@/pages/ProfileViewPage";
+import RandomRoulettePage from "@/pages/RandomRoulettePage";
 import WaitingRoomPage from "@/pages/WaitingRoomPage";
-import MenuSelectPage from "./pages/MenuSelectPage";
-import TopicRecommendPage from "./pages/TopicRecommendPage";
 import { config } from "@/stackflow.config";
 import { basicUIPlugin } from "@stackflow/plugin-basic-ui";
 import { basicRendererPlugin } from "@stackflow/plugin-renderer-basic";
 import { lazy, stackflow } from "@stackflow/react/future";
+
+import MenuSelectPage from "./pages/MenuSelectPage";
+import TopicRecommendPage from "./pages/TopicRecommendPage";
 
 export const { Stack } = stackflow({
   config,
@@ -18,6 +20,7 @@ export const { Stack } = stackflow({
     ProfilePage,
     ProfileCheckPage,
     ProfileViewPage,
+    ManittoPage,
     CreateRoomPage: lazy(() => import("./pages/CreateRoomPage")),
     MenuSelectPage,
     WaitingRoomPage,


### PR DESCRIPTION
### 1️⃣ PR 타입 (PR Type)

<!-- 해당하는 곳에 `x`를 표시해주세요. -->

- [x] ✨ feat: 새로운 기능 추가
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 📝 docs: 문서 수정
- [ ] 🎨 style: 코드 스타일 변경 (포맷팅, 세미콜론 추가 등)
- [ ] chore: 빌드 스크립트 수정, 패키지 매니저 설정 변경 등

### 2️⃣ 변경 사항 (Changes)

- 프로필 보기 확인 페이지 구현
- 마니또 페이지 구현

### 3️⃣ 관련 이슈 (Related Issues)

- Close #27

### 4️⃣ 코드 설명 (Description)

#### 프로필 보기 확인 페이지
- 맴버들의 준비 상태 확인 가능
- 준비 완료 버튼 클릭 시 준비 상태가 '준비 완료'로 변경됨 (맨 위에 있는 사람이 user)
- 모든 맴버 준비 완료 시 메뉴 선택 페이지로 이동
- 마니또 클릭 시 마니또 페이지로 이동
- 프로필 보기 페이지의 ProfileCard 컴포넌트 재사용
- 피그마에는 아래에 5초 제한 progressbar가 있는데 후에 이동할 페이지도 없고 의미가 없다는 생각이 들어서 우선은 구현하지 않았습니다.

### 5️⃣ 스크린샷 (Screenshots)

<p align="center">
  <img src="https://github.com/user-attachments/assets/db52b4ac-63ed-4fda-9f55-ec4ae3b2bf4d" width="48%">
  <img src="https://github.com/user-attachments/assets/ddc7549e-e109-4ed5-819e-061167a09374" width="48%">
</p>

### ✅ 체크리스트 (Checklist)

- [x] `base branch`를 확인했나요?
- [x] `self-review`를 진행했나요?
- [x] 관련 이슈를 연결했나요?
- [x] 커밋 컨벤션을 준수했나요?
- [x] PR 제목 컨벤션을 준수했나요?
