### PR TITLE
Feature#63 마니또 정보 추가

### DIFF
--- a/src/__test__/StageNavigator.error-handling.test.ts
+++ b/src/__test__/StageNavigator.error-handling.test.ts
@@ -93,13 +93,7 @@ describe("StageNavigator - 에러 핸들링", () => {
 
       handleMessage(nullBodyMessage);
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({
-          code: "STOMP_MESSAGE_PARSE_ERROR",
-          metadata: expect.any(Object),
-        }),
-      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith("메시지 파싱 실패", null);
       expect(mockNavigate).not.toHaveBeenCalled();
 
       consoleErrorSpy.mockRestore();
@@ -117,13 +111,7 @@ describe("StageNavigator - 에러 핸들링", () => {
 
       handleMessage(undefinedBodyMessage);
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({
-          code: "STOMP_MESSAGE_PARSE_ERROR",
-          metadata: expect.any(Object),
-        }),
-      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith("메시지 파싱 실패", undefined);
       expect(mockNavigate).not.toHaveBeenCalled();
 
       consoleErrorSpy.mockRestore();
@@ -141,13 +129,7 @@ describe("StageNavigator - 에러 핸들링", () => {
 
       handleMessage(emptyBodyMessage);
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({
-          code: "STOMP_MESSAGE_PARSE_ERROR",
-          metadata: expect.any(Object),
-        }),
-      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith("메시지 파싱 실패", "");
       expect(mockNavigate).not.toHaveBeenCalled();
 
       consoleErrorSpy.mockRestore();
@@ -186,7 +168,7 @@ describe("StageNavigator - 에러 핸들링", () => {
         handleMessage(msg as IMessage);
       });
 
-      expect(consoleErrorSpy).toHaveBeenCalledTimes(corruptedMessages.length);
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(corruptedMessages.length * 2);
       expect(mockNavigate).not.toHaveBeenCalled();
 
       consoleErrorSpy.mockRestore();
@@ -205,7 +187,7 @@ describe("StageNavigator - 에러 핸들링", () => {
         handleMessage(invalidMessage);
       }
 
-      expect(consoleErrorSpy).toHaveBeenCalledTimes(errorCount);
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(errorCount * 2);
 
       const internal = stageNavigator as unknown as StageNavigatorTestType;
       expect(internal.currentRoomId).toBe("room-123");
@@ -272,7 +254,7 @@ describe("StageNavigator - 에러 핸들링", () => {
         handleMessage(message);
       }).not.toThrow();
 
-      expect(consoleErrorSpy).toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith("페이지 네비게이션 실패", expect.any(Error));
 
       consoleErrorSpy.mockRestore();
     });

--- a/src/__test__/StageNavigator.error-handling.test.ts
+++ b/src/__test__/StageNavigator.error-handling.test.ts
@@ -238,7 +238,8 @@ describe("StageNavigator - 에러 핸들링", () => {
     it("getPageFromStage가 예외를 던져도 에러를 처리해야 한다", () => {
       const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-      vi.mocked(getPageFromStage).mockImplementationOnce(() => {
+      vi.mocked(getPageFromStage).mockReset();
+      vi.mocked(getPageFromStage).mockImplementation(() => {
         throw new Error("Invalid stage");
       });
 
@@ -257,6 +258,8 @@ describe("StageNavigator - 에러 핸들링", () => {
 
       expect(consoleErrorSpy).toHaveBeenCalledWith("페이지 네비게이션 실패", expect.any(Error));
 
+      // cleanup
+      vi.mocked(getPageFromStage).mockReset();
       consoleErrorSpy.mockRestore();
     });
   });

--- a/src/__test__/StageNavigator.error-handling.test.ts
+++ b/src/__test__/StageNavigator.error-handling.test.ts
@@ -200,6 +200,7 @@ describe("StageNavigator - 에러 핸들링", () => {
   describe("부분 데이터 손실", () => {
     beforeEach(() => {
       vi.mocked(stompService.subscribe).mockReturnValue(mockUnsubscribe);
+      vi.mocked(getPageFromStage).mockReset();
     });
 
     it("data.stage가 null이면 네비게이션하지 않아야 한다", () => {
@@ -237,7 +238,7 @@ describe("StageNavigator - 에러 핸들링", () => {
     it("getPageFromStage가 예외를 던져도 에러를 처리해야 한다", () => {
       const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-      vi.mocked(getPageFromStage).mockImplementation(() => {
+      vi.mocked(getPageFromStage).mockImplementationOnce(() => {
         throw new Error("Invalid stage");
       });
 

--- a/src/__test__/StageNavigator.test.ts
+++ b/src/__test__/StageNavigator.test.ts
@@ -397,13 +397,7 @@ describe("StageNavigator", () => {
 
       handleMessage(message);
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({
-          code: "STOMP_MESSAGE_PARSE_ERROR",
-          metadata: expect.any(Object),
-        }),
-      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith("메시지 파싱 실패", "invalid json");
       expect(mockNavigate).not.toHaveBeenCalled();
 
       consoleErrorSpy.mockRestore();

--- a/src/__test__/handleStompError.test.ts
+++ b/src/__test__/handleStompError.test.ts
@@ -75,7 +75,7 @@ describe("handleStompError", () => {
 
       handleStompError(message);
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith("에러 메시지 파싱 실패:", expect.any(Error));
+      expect(consoleErrorSpy).toHaveBeenCalledWith("에러 메시지 파싱 실패:", "invalid json");
     });
 
     it("빈 문자열이면 파싱 실패 에러를 로깅해야 한다", () => {
@@ -85,7 +85,7 @@ describe("handleStompError", () => {
 
       handleStompError(message);
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith("에러 메시지 파싱 실패:", expect.any(Error));
+      expect(consoleErrorSpy).toHaveBeenCalledWith("에러 메시지 파싱 실패:", "");
     });
   });
 

--- a/src/components/menuselect/MenuList.tsx
+++ b/src/components/menuselect/MenuList.tsx
@@ -2,6 +2,7 @@ import type { MenuId } from "@/components/menuselect";
 import { MENU } from "@/constants";
 import { useStompPublish, useStompSubscription } from "@/hooks/stomp";
 import { setLastEventType } from "@/hooks/useStageNavigation";
+import { getMessageBody } from "@/utils/stomp/getMessageBody";
 import type { IMessage } from "@stomp/stompjs";
 import { useCallback, useEffect } from "react";
 import { useSearchParams } from "react-router-dom";
@@ -17,16 +18,17 @@ export const MenuList = () => {
   const { publish, isConnected } = useStompPublish();
 
   const handleGameListMessage = useCallback((message: IMessage) => {
-    try {
-      const response = JSON.parse(message.body) as BaseResponse<string[]>;
+    const response = getMessageBody<BaseResponse<string[]>>(message);
 
-      if (response.success) {
-        //TODO : data랑 Menu 어떻게 섞을지
-      } else {
-        console.error("게임 목록 조회 실패", response.message);
-      }
-    } catch (error) {
-      console.error("메시지 파싱 실패", error, message.body);
+    if (!response) {
+      console.error("메시지 파싱 실패", message.body);
+      return;
+    }
+
+    if (response.success) {
+      //TODO : data랑 Menu 어떻게 섞을지
+    } else {
+      console.error("게임 목록 조회 실패", response.message);
     }
   }, []);
 

--- a/src/components/profileview/ProfileCardSkeleton.tsx
+++ b/src/components/profileview/ProfileCardSkeleton.tsx
@@ -1,0 +1,38 @@
+export const ProfileCardSkeleton = () => {
+  return (
+    <article
+      className="mb-6 h-[470px] w-[300px] max-w-sm rounded-2xl bg-white px-6 py-5 shadow-md"
+      aria-label="프로필 로딩 중"
+    >
+      <header className="mb-4 flex justify-center">
+        <div className="h-25 w-25 animate-pulse rounded-full bg-gray-200 shadow-md" />
+      </header>
+
+      <div className="mb-4 flex justify-center">
+        <div className="h-8 w-32 animate-pulse rounded bg-gray-200" />
+      </div>
+
+      <section className="mb-4 flex justify-center space-x-4" aria-label="기본 정보 로딩 중">
+        <div className="h-5 w-16 animate-pulse rounded bg-gray-200" />
+        <div className="h-5 w-16 animate-pulse rounded bg-gray-200" />
+      </section>
+
+      <section className="mb-6" aria-label="관심사 로딩 중">
+        <div className="flex flex-wrap justify-center gap-2">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <div key={index} className="h-7 w-16 animate-pulse rounded-full bg-gray-200" />
+          ))}
+        </div>
+      </section>
+
+      <section aria-label="한줄 소개 로딩 중">
+        <div className="mb-2 h-4 w-20 animate-pulse rounded bg-gray-200" />
+        <div className="space-y-2">
+          <div className="h-3 w-full animate-pulse rounded bg-gray-200" />
+          <div className="h-3 w-full animate-pulse rounded bg-gray-200" />
+          <div className="h-3 w-3/4 animate-pulse rounded bg-gray-200" />
+        </div>
+      </section>
+    </article>
+  );
+};

--- a/src/components/profileview/index.tsx
+++ b/src/components/profileview/index.tsx
@@ -1,4 +1,5 @@
 export { ProfileCard } from "./ProfileCard";
+export { ProfileCardSkeleton } from "./ProfileCardSkeleton";
 export { PageDots } from "./PageDots";
 export { ProfileViewLoading } from "./ProfileViewLoading";
 export { ProfileNavigationHint } from "./ProfileNavigationHint";

--- a/src/hooks/createroom/useCreateRoomAction.ts
+++ b/src/hooks/createroom/useCreateRoomAction.ts
@@ -2,6 +2,7 @@ import type { CreateRoomActionReturn } from "@/hooks/createroom";
 import type { CreateRoomResponse } from "@/hooks/createroom/types";
 import { useStompPublish, useStompSubscription } from "@/hooks/stomp";
 import type { CreateRoomFormSchemaType } from "@/model/CreateRoomFormSchema";
+import { getMessageBody } from "@/utils/stomp/getMessageBody";
 import type { IMessage } from "@stomp/stompjs";
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -17,18 +18,19 @@ export const useCreateRoomAction = (
   const [shouldSubscribe, setShouldSubscribe] = useState(true);
 
   const handleWaitingRoomMessage = useCallback((message: IMessage) => {
-    try {
-      const response = JSON.parse(message.body) as CreateRoomResponse;
+    const response = getMessageBody<CreateRoomResponse>(message);
 
-      const newRoomId = response.data?.roomId;
+    if (!response) {
+      setIsCreating(false);
+      return;
+    }
 
-      if (newRoomId && response.success) {
-        setCreatedRoomId(newRoomId);
-        setShouldSubscribe(false);
-      } else {
-        setIsCreating(false);
-      }
-    } catch {
+    const newRoomId = response.data?.roomId;
+
+    if (newRoomId && response.success) {
+      setCreatedRoomId(newRoomId);
+      setShouldSubscribe(false);
+    } else {
       setIsCreating(false);
     }
   }, []);

--- a/src/hooks/profileview/useRoomParticipants.ts
+++ b/src/hooks/profileview/useRoomParticipants.ts
@@ -17,6 +17,7 @@ export const useRoomParticipants = (roomId: string) => {
   const isHost = searchParams.get("isHost") === "true";
   const [participants, setParticipants] = useState<Participant[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  // TODO : 백엔드 마니또 데이터가 정상이 되면 제거
   const roomParticipants = useUserStore((state) => state.setParticipants);
   const handleParticipantMessage = useCallback(
     (message: IMessage) => {

--- a/src/services/stomp/StageNavigator.ts
+++ b/src/services/stomp/StageNavigator.ts
@@ -99,14 +99,18 @@ class StageNavigator {
     const lastEventType = this.lastEventTypeMap.get(this.currentRoomId);
 
     if (stage) {
-      const pageUrl = getPageFromStage(stage, this.currentRoomId, this.isHost);
-      if (pageUrl) {
-        if (lastEventType === "PREV") {
-          this.navigate(pageUrl, { state: { direction: "back" } });
-        } else {
-          this.navigate(pageUrl, { state: { direction: "forward" } });
+      try {
+        const pageUrl = getPageFromStage(stage, this.currentRoomId, this.isHost);
+        if (pageUrl) {
+          if (lastEventType === "PREV") {
+            this.navigate(pageUrl, { state: { direction: "back" } });
+          } else {
+            this.navigate(pageUrl, { state: { direction: "forward" } });
+          }
+          this.lastEventTypeMap.delete(this.currentRoomId);
         }
-        this.lastEventTypeMap.delete(this.currentRoomId);
+      } catch (error) {
+        console.error("페이지 네비게이션 실패", error);
       }
     }
   };

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -19,9 +19,6 @@ export const useAuthStore = create<AuthState>()(
     {
       name: "icebreaking-auth",
       storage: createJSONStorage(() => localStorage),
-      //TODO : 토큰 저장 방식을 어떻게 할지, XSS생각하면 토큰을 메모리에 저장
-      // partialize를 적용하면 새로고침 시 토큰이 사라져 재접속(재연결)시 힘들 수 있음
-      // partialize: (state) => ({ id: state.id }),
     },
   ),
 );

--- a/src/store/useUserStore.ts
+++ b/src/store/useUserStore.ts
@@ -1,0 +1,26 @@
+import type { Participant } from "@/hooks/profileview";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface UserStore {
+  participants: Participant[];
+  setParticipants: (participants: Participant[]) => void;
+  clearParticipants: () => void;
+  getParticipantByName: (name: string) => Participant | undefined;
+  getParticipantCount: () => number;
+}
+
+export const useUserStore = create<UserStore>()(
+  persist(
+    (set, get) => ({
+      participants: [],
+      setParticipants: (participants) => set({ participants }),
+      clearParticipants: () => set({ participants: [] }),
+      getParticipantByName: (name) => get().participants.find((p) => p.name === name),
+      getParticipantCount: () => get().participants.length,
+    }),
+    {
+      name: "icebreaking-users",
+    },
+  ),
+);

--- a/src/utils/stomp/getMessageBody.ts
+++ b/src/utils/stomp/getMessageBody.ts
@@ -1,5 +1,12 @@
 import type { IMessage } from "@stomp/stompjs";
 
+/**
+ * @warning 이 함수는 런타임 타입 검증을 수행하지 않습니다.
+ * 추후 zod 스키마 방식을 적용해야합니다.
+ * @template T - 파싱 결과로 기대하는 타입
+ * @param message - STOMP 메시지 객체
+ * @returns 파싱된 데이터 또는 실패 시 null
+ */
 export const getMessageBody = <T>(message: IMessage): T | null => {
   try {
     if (!message?.body) {

--- a/src/utils/stomp/getMessageBody.ts
+++ b/src/utils/stomp/getMessageBody.ts
@@ -1,0 +1,13 @@
+import type { IMessage } from "@stomp/stompjs";
+
+export const getMessageBody = <T>(message: IMessage): T | null => {
+  try {
+    if (!message?.body) {
+      return null;
+    }
+    return JSON.parse(message.body) as T;
+  } catch (e) {
+    console.error(e);
+    return null;
+  }
+};

--- a/src/utils/stomp/handleStompError.ts
+++ b/src/utils/stomp/handleStompError.ts
@@ -1,19 +1,23 @@
 import { StompErrorFactory } from "@/errors/stomp-error-factory";
 import type { IMessage } from "@stomp/stompjs";
 
+import { getMessageBody } from "./getMessageBody";
+
 export const handleStompError = (message: IMessage): void => {
-  try {
-    const response = JSON.parse(message.body);
-    const stompError = StompErrorFactory.fromBackendErrorResponse(response);
+  const response = getMessageBody<BaseErrorResponse>(message);
 
-    console.error("백엔드 에러 수신:", {
-      code: stompError.code,
-      message: stompError.message,
-      metadata: stompError.metadata,
-    });
-
-    // TODO : 에러를 토스트같은 UI로 표시해주기
-  } catch (error) {
-    console.error("에러 메시지 파싱 실패:", error);
+  if (!response) {
+    console.error("에러 메시지 파싱 실패:", message.body);
+    return;
   }
+
+  const stompError = StompErrorFactory.fromBackendErrorResponse(response);
+
+  console.error("백엔드 에러 수신:", {
+    code: stompError.code,
+    message: stompError.message,
+    metadata: stompError.metadata,
+  });
+
+  // TODO : 에러를 토스트같은 UI로 표시해주기
 };


### PR DESCRIPTION
### 1️⃣ PR 타입 (PR Type)

<!-- 해당하는 곳에 `x`를 표시해주세요. -->

- [x] ✨ feat: 새로운 기능 추가


### 2️⃣ 변경 사항 (Changes)

- 메시지 파싱 함수 `getMessageBody`추가
- 참가자 목록 저장을 위한 `useUserStore`추가
- 마니또 로딩 중 스켈레톤 UI추가

### 3️⃣ 관련 이슈 (Related Issues)

- resolve #63 

### 4️⃣ 코드 설명 (Description)

- 서버로부터 메시지를 받고 `JSON.parse`하는 반복 로직을 `getMessageBody`로 변경
  - 기존 타입 단언을 직접 하는 대신, `getMessageBody<T>`로 제네릭으로 받도록 작성
- 스켈레톤 UI추가
  - 마니또 정보를 불러오는 중 스켈레톤 UI를 추가하여 로딩 중 CLS 방지
- 참가자 목록 저장을 위해 별도의 store추가
  - 서버에서 마니또에 대한 이름만 내려주기 때문에 임시로 store에 저장된 사용자 목록 중 찾아서 추가

### ✅ 체크리스트 (Checklist)

- [x] `base branch`를 확인했나요?
- [x] `self-review`를 진행했나요?
- [x] 관련 이슈를 연결했나요?
- [x] 커밋 컨벤션을 준수했나요?
- [x] PR 제목 컨벤션을 준수했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 프로필 카드 로딩용 스켈레톤 UI 추가(접근성 라벨 포함)
  * 참가자 관리용 영속 스토어 추가(참여자 조회/갱신 기능)

* **Bug Fixes**
  * 메시지 파싱을 중앙화된 안전 유틸로 대체해 파싱 실패 시 로깅·조기복구 강화
  * 대기실·생성·참가자 업데이트 등 여러 흐름의 안정성 및 상태 업데이트 개선
  * 파싱 실패 시 토스트 알림 및 명확한 에러 로깅 보강

* **Tests**
  * 에러 로깅 기대치와 관련 테스트 업데이트

* **Chores**
  * 불필요한 주석 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->